### PR TITLE
chore(release): 0.6.0

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
       { text: 'Examples', link: '/examples/basic' },
       { text: 'Playground', link: '/examples/playground' },
       {
-        text: 'v0.5.1',
+        text: 'v0.6.0',
         items: [
           {
             text: 'Changelog',

--- a/docs/.vitepress/theme/components/Demo.vue
+++ b/docs/.vitepress/theme/components/Demo.vue
@@ -22,7 +22,7 @@ const props = withDefaults(
     editable?: boolean;
   }>(),
   {
-    json: '{\n  "name": "Vue3 JSON Viewer",\n  "version": "0.5.1",\n  "features": ["dark mode", "expand/collapse", "events", "copy"],\n  "stats": { "stars": 128, "downloads": 42000, "typescript": true },\n  "createdAt": "2024-01-01T00:00:00.000Z",\n  "maintainer": null\n}',
+    json: '{\n  "name": "Vue3 JSON Viewer",\n  "version": "0.6.0",\n  "features": ["dark mode", "expand/collapse", "events", "copy"],\n  "stats": { "stars": 128, "downloads": 42000, "typescript": true },\n  "createdAt": "2024-01-01T00:00:00.000Z",\n  "maintainer": null\n}',
     dark: true,
     expanded: true,
     controls: false,

--- a/docs/examples/playground.md
+++ b/docs/examples/playground.md
@@ -24,7 +24,7 @@ the event log shows the `@toggle` / `@copy` events as you interact.
 
   const darkMode = ref(true);
   const expanded = ref(true);
-  const data = shallowRef({ name: 'Vue3 JSON Viewer', version: '0.5.1' });
+  const data = shallowRef({ name: 'Vue3 JSON Viewer', version: '0.6.0' });
 
   const onToggle = (e: ToggleEventPayload) => console.log('toggle', e);
   const onCopy = (e: CopyEventPayload) => console.log('copy', e);

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -55,7 +55,7 @@ bun add @anilkumarthakur/vue3-json-viewer
 
   const jsonData = {
     name: 'Vue3 JSON Viewer',
-    version: '0.5.1',
+    version: '0.6.0',
     features: ['dark mode', 'expand/collapse', 'events', 'copy'],
   };
 </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anilkumarthakur/vue3-json-viewer",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "type": "module",
   "packageManager": "pnpm@9.15.9",
   "description": "A beautiful, customizable JSON viewer component for Vue 3 with TypeScript support, dark/light mode, expand/collapse controls, and syntax highlighting.",


### PR DESCRIPTION
Bumps the package version **0.5.1 → 0.6.0** (semver minor) for the feature release merged in #108.

### Included since 0.5.1 (all backward-compatible)
- Persistent expand/collapse state (survives collapsing an ancestor)
- Typed `@toggle` / `@copy` events with JSONPath-style paths
- New exported types: `JsonViewerEmits`, `ToggleEventPayload`, `CopyEventPayload`
- Hardened clipboard copy (never throws; `execCommand` fallback)
- Collision-safe node paths
- Full VitePress docs overhaul + pnpm 9 tooling/CI

### Changes here
- `package.json`: `version` → `0.6.0`
- Docs version selector → `v0.6.0`
- Sample data in docs updated to `0.6.0`

### After merge (publish steps)
1. `git tag v0.6.0 && git push origin v0.6.0`
2. `pnpm publish` (runs `prepublishOnly` → `pnpm build`)